### PR TITLE
API-717 :: Remove deprecation warning by calling the new method as suggested by warning

### DIFF
--- a/lib/checkr/canada/types.rb
+++ b/lib/checkr/canada/types.rb
@@ -22,7 +22,7 @@ module Checkr
 
     # Dry types + custom types
     module Types
-      include Dry::Types.module
+      include Dry.Types(default: :nominal)
 
       Status = Strict::String.enum(
         'pending', 'clear', 'consider', 'suspended'

--- a/lib/checkr/canada/version.rb
+++ b/lib/checkr/canada/version.rb
@@ -2,6 +2,6 @@
 
 module Checkr
   module Canada
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
There is a Deprecation warning in monolith due to the way we include `Dry::Types` in the `checkr-canada` gem.  This resolves it.

https://fountain.atlassian.net/browse/API-717

```sh
[dry-types] Dry::Types.module is deprecated and will be removed in the next major version
Use Dry.Types() instead. Beware, it exports strict types by default, for old behavior use Dry.Types(default: :nominal). See more options in the changelog
```